### PR TITLE
allow ssh keys to be specified by group as well as by explicit list

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,1 +1,2 @@
 default[:ssh_keys_keep_existing] = true
+default[:ssh_key_skip_missing_users] = false

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -37,6 +37,11 @@ if node[:ssh_keys]
       # Saving SSH keys
       if ssh_keys.length > 0
         home_dir = user['dir']
+
+        if not File.exists?(home_dir) and node[:ssh_keys_skip_missing_users]
+          next
+        end
+
         authorized_keys_file = "#{home_dir}/.ssh/authorized_keys"
 
         if node[:ssh_keys_keep_existing] && File.exist?(authorized_keys_file)

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -13,10 +13,24 @@ if node[:ssh_keys]
       # Preparing SSH keys
       ssh_keys = []
 
-      Array(bag_users).each do |bag_user|
+      if bag_users.kind_of?(Array)
+        bag_users_list = bag_users
+      else
+        bag_users_list = bag_users['users']
+      end
+
+      Array(bag_users_list).each do |bag_user|
         data = data_bag_item('users', bag_user)
         if data and data['ssh_keys']
           ssh_keys += Array(data['ssh_keys'])
+        end
+      end
+
+      if not bag_users.kind_of?(Array) and bag_users['groups'] != nil
+        bag_users['groups'].each do |group_name|
+          search(:users, 'groups:' + group_name) do |user|
+            ssh_keys += Array(user['ssh_keys'])
+          end
         end
       end
 


### PR DESCRIPTION
This is intended to be a backwards compatible change (if we find an array instead of a hash, treat that array as a list of users)