### PR TITLE
Add name for cookbook validation 

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -1,3 +1,4 @@
+name              'ssh-keys'
 maintainer        "Nickolay Kovalev"
 maintainer_email  "nickola@nickola.ru"
 license           "Apache 2.0"


### PR DESCRIPTION
Berkshelf, foodcritic, etc need name to function properly.  Adding the name of your choice will allow people who use these tools to use this cookbook without changes.

Thank you for making helpful cookbooks like this available to the community!
