### PR TITLE
gives the template a static source

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -47,6 +47,7 @@ if node[:ssh_keys]
 
         # Creating "authorized_keys"
         template authorized_keys_file do
+          source "authorized_keys.erb"
           owner user['uid']
           group user['gid'] || user['uid']
           mode "0600"


### PR DESCRIPTION
Hey, 
we're running chef-server 11.4.0 and the template couldn't be found without specifying the location ... 
if source is not given the chef-server expects the template to be found in templates/default/HOME/.ssh/authorized_keys.erb .
