### PR TITLE
Support for encrypted data bags.

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,1 +1,2 @@
 default[:ssh_keys_keep_existing] = true
+default[:ssh_keys_use_encrypted_data_bag] = false

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email  "nickola@nickola.ru"
 license           "Apache 2.0"
 description       "Creates \"authorized_keys\" in user \"~/.ssh\" directory from a data bag"
 long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version           "1.0"
+version           "1.1"
 
 %w{ubuntu debian redhat centos fedora freebsd}.each do |os|
   supports os

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -14,7 +14,10 @@ if node[:ssh_keys]
       ssh_keys = []
 
       Array(bag_users).each do |bag_user|
-        data = data_bag_item('users', bag_user)
+        data = node[:ssh_keys_use_encrypted_data_bag] ?
+          Chef::EncryptedDataBagItem.load('users', bag_user) :
+          data_bag_item('users', bag_user)
+
         if data and data['ssh_keys']
           ssh_keys += Array(data['ssh_keys'])
         end


### PR DESCRIPTION
Supports encrypted data bags with the following flag:

``` ruby
node[:ssh_keys_use_encrypted_data_bag] = true # default false
```
