### PR TITLE
Support to define ssh_keys from node attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 Description
 ===========
 
-Creates `authorized_keys` in user `~/.ssh` directory from a data bag (encrypted data bag supported).
+Creates `authorized_keys` in user `~/.ssh` directory from a data bag (encrypted data bag supported) or node attributes.
 
 Attributes
 ==========
 
 Expects `node[:ssh_keys]` to be an hash containing the user name as key and data bag user name as value.
-Also, users can be defined by groups (see usage examples below).
+Also, users can be defined by groups or node attributes (see usage examples below).
 
 See `attributes/default.rb` for additional attributes default values.
 
@@ -58,6 +58,17 @@ Node configuration example to create `authorized_keys` for user `root` from data
       ]
     }
 
+Node configuration example to create `authorized_keys` for user `root` from `ssh_keys` attribute:
+
+    {
+      "ssh_keys": {
+        "root": {"ssh_keys": ["ssh-rsa AAAAB3Nz...oBUw== user"]}
+      },
+      "run_list": [
+        "recipe[ssh-keys]"
+      ]
+    }
+
 Use knife to create a data bag for users:
 
     knife data bag create users
@@ -75,6 +86,8 @@ User data bag example (compatible with Chef [users cookbook](https://github.com/
       "id": "user2",
       "ssh_keys": "ssh-rsa AAAAB3Nz...5D8F== user2"
     }
+
+Data bag is not required if you only want to use the `ssh_keys` attribute in node configuration.
 
 Cookbook URLs
 =============

--- a/metadata.rb
+++ b/metadata.rb
@@ -2,7 +2,7 @@ name              "ssh-keys"
 maintainer        "Nickolay Kovalev"
 maintainer_email  "nickola@nickola.ru"
 license           "Apache 2.0"
-description       "Creates \"authorized_keys\" in user \"~/.ssh\" directory from a data bag (encrypted data bag supported)"
+description       "Creates \"authorized_keys\" in user \"~/.ssh\" directory from a data bag (encrypted data bag supported) or node attributes"
 long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version           "1.2.7"
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -32,16 +32,20 @@ if node['ssh_keys']
         end
       end
 
-      if not bag_users.kind_of?(String) and not bag_users.kind_of?(Array) and bag_users['groups'] != nil
-        Array(bag_users['groups']).each do |group_name|
-          if not Chef::Config[:solo]
-            search(:users, 'groups:' + group_name) do |search_user|
-              ssh_keys += Array(search_user['ssh_keys'])
+      if not bag_users.kind_of?(String) and not bag_users.kind_of?(Array)
+        if bag_users['groups'] != nil
+          Array(bag_users['groups']).each do |group_name|
+            if not Chef::Config[:solo]
+              search(:users, 'groups:' + group_name) do |search_user|
+                ssh_keys += Array(search_user['ssh_keys'])
+              end
+            else
+              Chef::Log.warn("[ssh-keys] This recipe uses search for users detection by groups. Chef Solo does not support search.")
             end
-          else
-            Chef::Log.warn("[ssh-keys] This recipe uses search for users detection by groups. Chef Solo does not support search.")
           end
-        end
+        elsif bag_users['ssh_keys'] != nil
+          ssh_keys += Array(bag_users['ssh_keys'])
+        end 
       end
 
       # Saving SSH keys


### PR DESCRIPTION
Adds support to define the ssh auth keys of users directly from node attributes without defining a data bag.
